### PR TITLE
impl : broadcast multi-messages #97

### DIFF
--- a/comm_test.go
+++ b/comm_test.go
@@ -52,7 +52,8 @@ func TestGrpcServer(t *testing.T) {
 			conn.Close()
 		}
 	}
-	server := cleisthenes.NewServer(cleisthenes.Address{Ip: "127.0.0.1", Port: 8080})
+	availablePort := GetAvailablePort(8000)
+	server := cleisthenes.NewServer(cleisthenes.Address{Ip: "127.0.0.1", Port: availablePort})
 	server.OnConn(onConnection)
 	go server.Listen()
 
@@ -65,7 +66,7 @@ func TestGrpcServer(t *testing.T) {
 	conn, err := cli.Dial(cleisthenes.DialOpts{
 		Addr: cleisthenes.Address{
 			Ip:   "127.0.0.1",
-			Port: 8080,
+			Port: availablePort,
 		},
 		Timeout: cleisthenes.DefaultDialTimeout,
 	})

--- a/conn.go
+++ b/conn.go
@@ -180,7 +180,11 @@ func (conn *GrpcConnection) readStream(errChan chan error) {
 }
 
 type Broadcaster interface {
-	Broadcast(msg pb.Message)
+	// ShareMessage is a function that broadcast Single message to all nodes
+	ShareMessage(msg pb.Message)
+
+	// DistributeMessage is a function that broadcast Multiple messages one by one to all nodes
+	DistributeMessage(msgList []pb.Message)
 }
 
 type ConnectionPool struct {
@@ -201,9 +205,18 @@ func (p *ConnectionPool) GetAll() []Connection {
 	return connList
 }
 
-func (p *ConnectionPool) Broadcast(msg pb.Message) {
+func (p *ConnectionPool) ShareMessage(msg pb.Message) {
 	for _, conn := range p.connMap {
 		conn.Send(msg, nil, nil)
+	}
+}
+
+func (p *ConnectionPool) DistributeMessage(msgList []pb.Message) {
+	for i, conn := range p.GetAll() {
+		if i == len(msgList) {
+			break
+		}
+		conn.Send(msgList[i], nil, nil)
 	}
 }
 


### PR DESCRIPTION
## Related Issue

resolve: #97 

## Description

- implements BroadcastMessages() at conn.go that broadcast multi-messages to all nodes one by one.
- implements test case for BroadcastMessages at `conn_test.go`
- add one more case for TestConnectionPool_BroadcastMessage at `conn_test.go`
- modify setting port at `conn_test.go` and `comm_test.go`

## Checklist

Thank you for your contribution.
Before submitting this PR, please make sure:

- [x] Applying goimports
- [x] Test case
- [x] End of Work

