### PR TITLE
bug : add port duplication protecting code and mutex lock

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -381,7 +381,7 @@ func TestConnectionPool_Add(t *testing.T) {
 }
 
 func TestConnectionPool_Remove(t *testing.T) {
-	cAddr := cleisthenes.Address{"127.0.0.1", 8000}
+	cAddr := cleisthenes.Address{"127.0.0.1", GetAvailablePort(8000)}
 	mockStreamWrapper := mock.NewStreamWrapper()
 	cp := cleisthenes.NewConnectionPool()
 


### PR DESCRIPTION
## Related Issue

resolve: #101

## Description

- add port duplication protecting code and mutex lock

## Checklist

Thank you for your contribution.
Before submitting this PR, please make sure:

- [x] Applying goimports
- [ ] Test case
- [x] End of Work

