### PR TITLE
fix : Fix bba async logic

### DIFF
--- a/bba/bba_internal_test.go
+++ b/bba/bba_internal_test.go
@@ -103,7 +103,7 @@ func setupHandleBvalRequestTest(t *testing.T, bvalList []*BvalRequest) (*BBA, *m
 		round:              newRound(),
 		reqChan:            make(chan request),
 
-		binValueChan:  make(chan struct{}, 10),
+		binValueChan:  make(chan uint64, 10),
 		Tracer:        cleisthenes.NewMemCacheTracer(),
 		coinGenerator: mock.NewCoinGenerator(cleisthenes.Coin(cleisthenes.One)),
 	}
@@ -311,7 +311,10 @@ func setupHandleAuxRequestTest(t *testing.T, auxList []*AuxRequest) (*BBA, *mock
 		f:                   3,
 		auxRepo:             newAuxReqRepository(),
 		broadcaster:         broadcaster,
-		tryoutAgreementChan: make(chan struct{}, 10),
+		binValueSet:         newBinarySet(),
+		round:               newRound(),
+		incomingAuxReqRepo:  newDefaultIncomingRequestRepository(),
+		tryoutAgreementChan: make(chan uint64, 10),
 		Tracer:              cleisthenes.NewMemCacheTracer(),
 		coinGenerator:       mock.NewCoinGenerator(cleisthenes.Coin(cleisthenes.One)),
 	}
@@ -336,6 +339,8 @@ func TestBBA_HandleAuxRequest(t *testing.T) {
 	}
 
 	bbaInstance, _, tester, teardown := setupHandleAuxRequestTest(t, auxList)
+	// after bval is set
+	bbaInstance.binValueSet.union(cleisthenes.One)
 	defer teardown()
 
 	go func() {
@@ -397,6 +402,8 @@ func TestBBA_HandleAuxRequest_OneZeroCombined(t *testing.T) {
 	}
 
 	bbaInstance, _, tester, teardown := setupHandleAuxRequestTest(t, auxList)
+	// after bval is set
+	bbaInstance.binValueSet.union(cleisthenes.One)
 	defer teardown()
 
 	go func() {
@@ -456,8 +463,8 @@ func tryoutAgreementTestSetup() (*BBA, *bbaTester, func()) {
 		est:                 cleisthenes.NewBinaryState(),
 		dec:                 cleisthenes.NewBinaryState(),
 		round:               newRound(),
-		tryoutAgreementChan: make(chan struct{}, 10),
-		advanceRoundChan:    make(chan struct{}, 10),
+		tryoutAgreementChan: make(chan uint64, 10),
+		advanceRoundChan:    make(chan uint64, 10),
 		Tracer:              cleisthenes.NewMemCacheTracer(),
 		coinGenerator:       mock.NewCoinGenerator(cleisthenes.Coin(cleisthenes.One)),
 		binInputChan:        cleisthenes.NewBinaryChannel(10),

--- a/bba/request.go
+++ b/bba/request.go
@@ -161,6 +161,8 @@ func (r *defaultIncomingReqRepository) Find(round uint64) []*incomingRequest {
 			continue
 		}
 		result = append(result, ir)
+
 	}
+
 	return result
 }

--- a/coin.go
+++ b/coin.go
@@ -3,5 +3,5 @@ package cleisthenes
 type Coin Binary
 
 type CoinGenerator interface {
-	Coin() Coin
+	Coin(uint64) Coin
 }

--- a/test/bba/node.go
+++ b/test/bba/node.go
@@ -75,7 +75,7 @@ func New(typ NodeType, n, f int, coinGenerator cleisthenes.CoinGenerator, addr c
 	connPool := cleisthenes.NewConnectionPool()
 	memberMap := cleisthenes.NewMemberMap()
 	binChan := cleisthenes.NewBinaryChannel(n)
-	bba := engine.New(n, f, *member, cleisthenes.Member{}, connPool, coinGenerator, binChan)
+	bba := engine.New(n, f, *member, cleisthenes.Member{}, connPool, binChan)
 	return &Node{
 		typ:       typ,
 		addr:      addr,

--- a/test/mock/coin.go
+++ b/test/mock/coin.go
@@ -18,8 +18,6 @@ func NewCoinGenerator(seed cleisthenes.Coin) *CoinGenerator {
 	}
 }
 
-func (g *CoinGenerator) Coin() cleisthenes.Coin {
-	result := g.Seed
-	g.Seed = !g.Seed
-	return result
+func (g *CoinGenerator) Coin(salt uint64) cleisthenes.Coin {
+	return cleisthenes.Coin(salt%2 != 0)
 }


### PR DESCRIPTION
## Related Issue


## Description

- when raising round, need to follow one context. fix compare logic to channel.
- when send delayed message, `Bval` should arrive first and `Aux` second.

## Checklist

Thank you for your contribution.
Before submitting this PR, please make sure:

- [x] Applying goimports
- [x] Test case
- [x] End of Work

